### PR TITLE
fix pip update

### DIFF
--- a/30_create_users.yml
+++ b/30_create_users.yml
@@ -10,8 +10,8 @@
         state: present
       become: true
 
-    - name: pip self-update
-      pip:
+    - name: Ensure pip is up to date
+      ansible.builtin.pip:
         name: pip
         state: latest
       become: true

--- a/30_create_users.yml
+++ b/30_create_users.yml
@@ -10,6 +10,12 @@
         state: present
       become: true
 
+    - name: pip self-update
+      pip:
+        name: pip
+        state: latest
+      become: true
+
     - name: Ensuring passlib is present
       ansible.builtin.pip:
         name:


### PR DESCRIPTION
prevents errors like:
 [bastion]: FAILED! => {"changed": false, "cmd": ["/usr/libexec/platform-python", "-m", "pip.__main__", "install", "passlib", "bcrypt"], "msg": "stdout: Collecting passlib\n  Downloading https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl (525kB)\nCollecting bcrypt\n  Downloading https://files.pythonhosted.org/packages/99/f2/b71b9b5b2400fffac7d42c560ac89f302c4d8e328337b2f05f0a4d9e590d/bcrypt-4.0.0.tar.gz\n    Complete output from command python setup.py egg_info:\n    \n            =============================DEBUG ASSISTANCE==========================\n            If you are seeing an error here please try the following to\n            successfully install cryptography:\n    \n            Upgrade to the latest pip and try again. This will fix errors for most\n            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip\n            =============================DEBUG ASSISTANCE==========================\n    \n    Traceback (most recent call last):\n      File \"<string>\", line 1, in <module>\n      File \"/tmp/pip-build-xvwhxxqk/bcrypt/setup.py\", line 11, in <module>\n        from setuptools_rust import RustExtension\n    ModuleNotFoundError: No module named 'setuptools_rust'\n    \n    ----------------------------------------\n\n:stderr: WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.\nCommand \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-xvwhxxqk/bcrypt/\n"}